### PR TITLE
CI should run on master-merge

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,8 @@
 name: Java CI with Gradle
 
 on:
+  push:
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 


### PR DESCRIPTION
CI should also run on PR merge to master 
 -> PR merge issues a push on master, which triggers the Github workflow